### PR TITLE
fix hardcoded server name by using server var

### DIFF
--- a/tests/test-openshift_login.yml
+++ b/tests/test-openshift_login.yml
@@ -10,7 +10,7 @@
     openshift_login:
       username: "{{ openshift_test_login_username }}"
       password: "{{ openshift_test_login_password }}"
-      server: https://openshift-master.libvirt
+      server: "{{ openshift_connection_server }}" 
       insecure_skip_tls_verify: "true"
     register: openshift_login
 


### PR DESCRIPTION
hard coded server name fails on when trying to log into minishift